### PR TITLE
Treat + as a special charater

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -64,7 +64,7 @@ function removeLeadingSlash(filename) {
 function encodeSpecialCharacters(filename) {
   // Note: these characters are valid in URIs, but S3 does not like them for
   // some reason.
-  return encodeURI(filename).replace(/[!'()#* ]/g, function (char) {
+  return encodeURI(filename).replace(/[!'()#*+ ]/g, function (char) {
     return '%' + char.charCodeAt(0).toString(16);
   });
 }

--- a/test/knox.test.js
+++ b/test/knox.test.js
@@ -306,6 +306,17 @@ function runTestsForStyle(style, userFriendlyName) {
           done();
         });
       });
+
+      specify('with pluses in the file name', function (done) {
+        var buffer = new Buffer('a string of stuff');
+        var headers = { 'Content-Type': 'text/plain' };
+
+        client.putBuffer(buffer, '/buffer+with+pluses.txt', headers, function (err, res) {
+          assert.ifError(err);
+          assert.equal(res.statusCode, 200);
+          done();
+        });
+      });
     });
 
     describe('copy()', function () {
@@ -582,7 +593,7 @@ function runTestsForStyle(style, userFriendlyName) {
       it('should remove the files as seen in list()', function (done) {
         // Intentionally mix no leading slashes or leading slashes: see #121.
         var files = ['/test/user3.json', 'test/string.txt', '/test/apos\'trophe.txt', '/buffer.txt', '/buffer2.txt',
-                     'google', 'buffer with spaces.txt', '/ø', 'ø/ø', '/test/versioned.txt#1'];
+                     'google', 'buffer with spaces.txt', 'buffer+with+pluses.txt', '/ø', 'ø/ø', '/test/versioned.txt#1'];
         client.deleteMultiple(files, function (err, res) {
           assert.ifError(err);
           assert.equal(res.statusCode, 200);
@@ -598,6 +609,7 @@ function runTestsForStyle(style, userFriendlyName) {
             assert(keys.indexOf('buffer2.txt') === -1);
             assert(keys.indexOf('google') === -1);
             assert(keys.indexOf('buffer with spaces.txt') === -1);
+            assert(keys.indexOf('buffer+with+pluses.txt') === -1);
             assert(keys.indexOf('ø') === -1);
             assert(keys.indexOf('ø/ø') === -1);
             assert(keys.indexOf('/test/versioned.txt#1') === -1);


### PR DESCRIPTION
[Standards suggest](http://stackoverflow.com/a/1006074/407845) the `+` character should only be converted to a space in the query string, but S3 converts them all to spaces.  We have to escape them to get at a file with a `+` in its key.

This bit me when a user uploaded a file (via [filepicker](https://www.filepicker.io/)) with `+` in the name.