### PR TITLE
fix failing tests in node v0.11.14.

### DIFF
--- a/lib/auth.js
+++ b/lib/auth.js
@@ -205,7 +205,7 @@ exports.canonicalizeResource = function(resource){
     , buf = [];
 
   // apply the query string whitelist
-  Object.keys(url.query).forEach(function (key) {
+  Object.keys(url.query || {}).forEach(function (key) {
       if (whitelist.indexOf(key) != -1) {
           buf.push(key + (url.query[key] ? "=" + url.query[key] : ''));
       }


### PR DESCRIPTION
`Object.keys()` being called on a null query string was causing tests to fail on `node v0.11.14`.

To reproduce:

1. `nvm use v0.11.14`.
2. run the auth tests: `./node_modules/.bin/mocha test/auth.test.js`.